### PR TITLE
feat: add deep research report generator

### DIFF
--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -1,0 +1,44 @@
+name: deep-research-report
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch main
+        run: git fetch origin main
+      - name: Check for problem.md changes
+        id: changes
+        run: |
+          base=$(git merge-base origin/main HEAD)
+          if git diff --quiet "$base" -- problem.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate report
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          FIREWORKS_KEY: ${{ secrets.FIREWORKS_KEY }}
+        run: |
+          if [ -z "$FIREWORKS_KEY" ]; then
+            echo "FIREWORKS_KEY secret is required" >&2
+            exit 1
+          fi
+          ./bin/generate-report
+      - name: Upload report artifact
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-research-report
+          path: report.md

--- a/bin/generate-report
+++ b/bin/generate-report
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure required secrets are present
+: "${FIREWORKS_KEY:?FIREWORKS_KEY is required}"
+
+# Required commands
+for cmd in docker git curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required" >&2
+    exit 1
+  fi
+done
+
+REPO="https://github.com/dzhng/deep-research"
+API="https://api.github.com/repos/dzhng/deep-research"
+
+# Prefer a tagged release from the last 2 weeks, fall back to main
+cutoff=$(date -u -d '2 weeks ago' +%s)
+ref="main"
+
+# Check latest release
+latest_release=$(curl -fs "$API/releases/latest" 2>/dev/null || true)
+if [ -n "$latest_release" ]; then
+  published=$(echo "$latest_release" | jq -r '.published_at')
+  if [ "$published" != "null" ]; then
+    published_ts=$(date -d "$published" +%s)
+    if [ "$published_ts" -ge "$cutoff" ]; then
+      ref=$(echo "$latest_release" | jq -r '.tag_name')
+    fi
+  fi
+fi
+
+# If no recent release, check tags
+if [ "$ref" = "main" ]; then
+  tags=$(curl -fs "$API/tags?per_page=10" 2>/dev/null || true)
+  if [ -n "$tags" ]; then
+    while read -r tag sha; do
+      commit_info=$(curl -fs "$API/commits/$sha" 2>/dev/null || true)
+      date=$(echo "$commit_info" | jq -r '.commit.committer.date')
+      if [ -n "$date" ]; then
+        date_ts=$(date -d "$date" +%s)
+        if [ "$date_ts" -ge "$cutoff" ]; then
+          ref="$tag"
+          break
+        fi
+      fi
+    done < <(echo "$tags" | jq -r '.[] | "\(.name) \(.commit.sha)"')
+  fi
+fi
+
+tmpdir=$(mktemp -d)
+network="deep-research-net"
+cleanup() {
+  rm -rf "$tmpdir"
+  docker rm -f deep-research-run >/dev/null 2>&1 || true
+  docker stop firecrawl >/dev/null 2>&1 || true
+  docker network rm "$network" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+git clone --depth 1 --branch "$ref" "$REPO" "$tmpdir"
+touch "$tmpdir/.env.local"
+
+# Build deep-research image
+docker build -t deep-research:local "$tmpdir" >/dev/null
+
+# Network and local Firecrawl
+if ! docker network inspect "$network" >/dev/null 2>&1; then
+  docker network create "$network" >/dev/null
+fi
+docker run -d --rm --name firecrawl --network "$network" ghcr.io/mendableai/firecrawl:latest >/dev/null
+
+# Condense problem.md into a single line for the prompt
+QUERY=$(tr '\n' ' ' < problem.md)
+
+# Run deep-research with local Firecrawl
+docker run -i --name deep-research-run --network "$network" \
+  -e FIREWORKS_KEY \
+  -e FIRECRAWL_BASE_URL=http://firecrawl:3002 \
+  deep-research:local <<EOF2
+${QUERY}
+4
+2
+EOF2
+
+docker cp deep-research-run:/app/report.md report.md >/dev/null


### PR DESCRIPTION
## Summary
- run deep-research inside Docker and self-host Firecrawl to avoid API usage
- generate report in CI only when `problem.md` changes, requiring `FIREWORKS_KEY`

## Testing
- `./bin/generate-report` *(fails: FIREWORKS_KEY is required)*

------
https://chatgpt.com/codex/tasks/task_e_68972bebe9a4832485898ff95245025a